### PR TITLE
Use unscaled delta time to animate opening/closing

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -318,7 +318,7 @@ namespace CommandTerminal
         }
 
         void HandleOpenness() {
-            float dt = ToggleSpeed * Time.deltaTime;
+            float dt = ToggleSpeed * Time.unscaledDeltaTime;
 
             if (current_open_t < open_target) {
                 current_open_t += dt;


### PR DESCRIPTION
This will avoid the case where console wouldn't work in games that implement pause via `Time.timeScale = 0`.