### PR TITLE
Accept input when keypad Enter is pressed

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -248,7 +248,8 @@ namespace CommandTerminal
 
             if (Event.current.Equals(Event.KeyboardEvent("escape"))) {
                 SetState(TerminalState.Close);
-            } else if (Event.current.Equals(Event.KeyboardEvent("return"))) {
+            } else if (Event.current.Equals(Event.KeyboardEvent("return"))
+                || Event.current.Equals(Event.KeyboardEvent("[enter]"))) {
                 EnterCommand();
             } else if (Event.current.Equals(Event.KeyboardEvent("up"))) {
                 command_text = History.Previous();


### PR DESCRIPTION
Previously, only "regular" Enter key would execute commands. This change enables executing commands by pressing keypad (numpad) Enter, in addition to the regular Enter key.