### PR TITLE
Add helper method to convert to any enum

### DIFF
--- a/CommandTerminal/CommandShell.cs
+++ b/CommandTerminal/CommandShell.cs
@@ -60,6 +60,19 @@ namespace CommandTerminal
             }
         }
 
+        public T AsEnum<T>()
+        {
+            try
+            {
+                return (T)Enum.Parse(typeof(T), String, true);
+            }
+            catch (ArgumentException)
+            {
+                TypeError(typeof(T).ToString());
+                return default (T);
+            }
+        }
+
         public override string ToString() {
             return String;
         }


### PR DESCRIPTION
This adds a helper to convert a command argument to the given enum type. I've created a method, instead of a property, so that it can accept a generic type.

The behavior is similar to the existing helpers, i.e. parsing is case insensitive and return the default value for the given type in case of an error.