### PR TITLE
Fix Debug.Log(); not routing through Terminal when using multi-threaded operations

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -138,11 +138,11 @@ namespace CommandTerminal
             Autocomplete = new CommandAutocomplete();
 
             // Hook Unity log events
-            Application.logMessageReceived += HandleUnityLog;
+            Application.logMessageReceivedThreaded += HandleUnityLog;
         }
 
         void OnDisable() {
-            Application.logMessageReceived -= HandleUnityLog;
+            Application.logMessageReceivedThreaded -= HandleUnityLog;
         }
 
         void Start() {


### PR DESCRIPTION
When calling Debug.Log or other Debug messages, the Application.logMessageReceived callback does not fire if that log message was not on the main thread.

Changing the callback to Application.logMessageReceivedThreaded means it will pick up on all log messages even if they weren't on the main thread.

I had to spend several hours today trying to figure out why my Debug Log was not firing because I was using command terminal to see the output. Once I looked in Unity I saw that some of my Debug Logs were not going through the command terminal. After further investigating I discovered it was because those Debug.Logs were not taking place on the main thread. This solved the issue.