### PR TITLE
Fix 'is never assigned to' warnings

### DIFF
--- a/CommandTerminal/Terminal.cs
+++ b/CommandTerminal/Terminal.cs
@@ -34,12 +34,12 @@ namespace CommandTerminal
         [Header("Input")]
         [SerializeField] Font ConsoleFont;
         [SerializeField] string InputCaret        = ">";
-        [SerializeField] bool ShowGUIButtons;
-        [SerializeField] bool RightAlignButtons;
+        [SerializeField] bool ShowGUIButtons      = false;
+        [SerializeField] bool RightAlignButtons   = false;
 
         [Header("Theme")]
         [Range(0, 1)]
-        [SerializeField] float InputContrast;
+        [SerializeField] float InputContrast      = 0.0f;
         [Range(0, 1)]
         [SerializeField] float InputAlpha         = 0.5f;
 


### PR DESCRIPTION
Unity was giving me 3 warnings:

```
Assets\3rdParty\CommandTerminal\Terminal.cs(42,32): warning CS0649: Field 'Terminal.InputContrast' is never assigned to, and will always have its default value 0

Assets\3rdParty\CommandTerminal\Terminal.cs(38,31): warning CS0649: Field 'Terminal.RightAlignButtons' is never assigned to, and will always have its default value false

Assets\3rdParty\CommandTerminal\Terminal.cs(37,31): warning CS0649: Field 'Terminal.ShowGUIButtons' is never assigned to, and will always have its default value false
```

I fixed them.